### PR TITLE
Shows the date in the tooltip text in iso8601 formatting

### DIFF
--- a/tracext/wiki/mypage.py
+++ b/tracext/wiki/mypage.py
@@ -272,11 +272,11 @@ class MyPageNavMacro(WikiMacroBase):
         mp = MyPageModule(self.env)
         base = mp.get_mypage_base(formatter.perm.username)
         all_mypages = mp.get_all_mypages(base)
+        tzinfo = getattr(formatter.context.req, 'tz', None)
         r = formatter.resource
         if r.realm == 'wiki' and r.id.startswith(base):
             mypage = r.id
         else:
-            tzinfo = getattr(formatter.context.req, 'tz', None)
             now = datetime.now(tzinfo or localtz)
             today = format_date(now, 'iso8601', tzinfo)
             mypage = '/'.join([base, today])
@@ -309,7 +309,7 @@ class MyPageNavMacro(WikiMacroBase):
         selected_day = selected.split('/')[-1]
         try:
             tooltip = _("MyPage for %(day)s",
-                        day=format_date(parse_date(selected_day)))
+                        day=format_date(parse_date(selected_day), 'iso8601', tzinfo))
         except TracError:
             tooltip = _("non-day page '%(special)'", special=selected_day)
         return tag.a(label if label is not None else selected, title=tooltip,


### PR DESCRIPTION
The 'prev' and 'next' links of the macro, also include the date of the linked next/prev page in the tooltip. However that date is not formatted in the iso8601 formatting, which is confusing because all the other dates are being interpreted as iso8601 dates by the plugin.

This patch also formats the date in the tooltip of the links in the iso8601 formatting.