### PR TITLE
Hide the 'MyPage' button from the navigation menu when the user doesn't have permission

### DIFF
--- a/tracext/wiki/mypage.py
+++ b/tracext/wiki/mypage.py
@@ -128,7 +128,8 @@ class MyPageModule(Component):
     def get_navigation_items(self, req):
         """Retrieve top-level ''MyPage'' entry.
         """
-        yield 'mainnav', 'mypage', tag.a(_("MyPage"), href=req.href.mypage())
+        if 'WIKI_VIEW' in req.perm:
+            yield 'mainnav', 'mypage', tag.a(_("MyPage"), href=req.href.mypage())
 
 
     # IRequestHandler methods


### PR DESCRIPTION
Hide the 'MyPage' button from the navigation menu when the user doesn't have the WIKI_VIEW permission.

On my own private Trac site, anonymous users do not have WIKI_VIEW permissions at all to hide all the content, so it is logical that the 'MyPage' button is also hidden.

When an user doesn't have access to the Wiki (because the WIKI_VIEW permission is not assigned), also the 'MyPage' button should not been shown. 