### PR TITLE
Use parse_date to determine if wiki page is a date-named page

### DIFF
--- a/tracext/wiki/mypage.py
+++ b/tracext/wiki/mypage.py
@@ -111,7 +111,20 @@ class MyPageModule(Component):
 
         (where `base` is usually as given by `get_mypage_base`)
         """
-        return sorted(WikiSystem(self.env).get_pages(base))
+        def parseable_date(date):
+            """Determines if the passed date can be parsed and converted
+            to a valid date
+            """
+            parseable = True
+            try:
+                day = parse_date(date)
+            except TracError:
+                parseable = False
+            return parseable
+
+        pages = list(WikiSystem(self.env).get_pages(base))
+        datepages = [pagepath for pagepath in pages if parseable_date(pagepath.split('/')[-1])]
+        return sorted(datepages)
 
     # INavigationContributor
 


### PR DESCRIPTION
In the Trac Wiki in which I am also using the MyPage plugin, the MyPage pages are included in a directory that also contains other (general purpose information) pages.

This is often causing problems with the 'Next ->' link of the MyPage plugin, because it is jumping to a wiki page without an iso8601 date.

I therefor suggest to include a check during the retrieval of all the pages in the 'base'. Only those pages of which the name of the page can be converted into a date should be included in the handling of the MyPage plugin. All other pages that have a different or unexpected name should be skipped.

The attached page implements this by calling the Trace parse_date() function on all the page names.