### PR TITLE
Fixes that the author's full name is reported by the $MYPAGE_AUTHOR token again

### DIFF
--- a/tracext/wiki/mypage.py
+++ b/tracext/wiki/mypage.py
@@ -192,7 +192,7 @@ class MyPageModule(Component):
                         ['> ' + line for line in last_page_text.splitlines()])
 
             today_user = user_time(req, format_date, now, tzinfo=tzinfo)
-            author = get_reporter_id(req)
+            author = req.session.get('name') or get_reporter_id(req)
 
             text = template_text \
                 .replace(self.tokens['date'][0], today_user) \


### PR DESCRIPTION
The token $MYPAGE_USER returns the author's user id.
The token $MYPAGE_AUTHOR should return the author's full name, however it is returning the author's user id, which is the same as $MYPAGE_USER. 

$MYPAGE_AUTHOR is using trac.util.get_reporter_id(req). That call returns req.authname by default if an user is authenticated. That is the same as $MYPAGE_USER.

The fix is using the name of the user from the logged on session, or it will fallback to the previous call if it cannot be determined. 
This fixes that the fullname of the user is again returned by the $MYPAGE_AUTHOR token.

Already tested and verified on my own trac website.

